### PR TITLE
Removing year

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
   - "0.10"
+notifications:
+  email:
+    on_success: change
+    on_failure: change

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/waneka/cron-builder.svg)](https://travis-ci.org/waneka/cron-builder)
+[![Build Status](https://travis-ci.org/srcclr/cron-builder.svg)](https://travis-ci.org/srcclr/cron-builder)
 # cron-builder
 cron-builder will manage the state of a cron expression allowing a user to manipulate it through a simple API. It is decoupled from the DOM and doesn't have an opinion about where it's being called from. cron-builder uses [this article](https://en.wikipedia.org/wiki/Cron) as a source of truth.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/waneka/cron-builder.svg)](https://travis-ci.org/waneka/cron-builder)
 # cron-builder
-cron-builder will manage the state of a cron expression allowing a user to manipulate it through a simple API. It is decoupled from the DOM and doesn't have an opinion about where it's being called from.
+cron-builder will manage the state of a cron expression allowing a user to manipulate it through a simple API. It is decoupled from the DOM and doesn't have an opinion about where it's being called from. cron-builder uses [this article](https://en.wikipedia.org/wiki/Cron) as a source of truth.
 
 ### Install
 cron-builder is available on npm and bower:
@@ -23,17 +23,17 @@ var cb = require('/path/to/cron-builder.js');
 To instantiate the cron builder:
 
 ```JavaScript
-// (default expression is set to "* * * * * *")
+// (default expression is set to "* * * * *")
 var cronExp = new cb();
 
 // optionally, pass in a cron expression to override the default:
-var myCronExp = new cb('5 12 * * 1-5 *')
+var myCronExp = new cb('5 12 * * 1-5')
 ```
 
 To return the cron expression at any given time:
 ```JavaScript
 cronExp.build();
-// '* * * * * *'
+// '* * * * *'
 ```
 
 API includes basic getters and setters:
@@ -45,7 +45,7 @@ cronExp.set('5,35', 'minute');
 cronExp.get('minute');
 // '5,35'
 cronExp.build();
-// '5,35 * * * * *'
+// '5,35 * * * *'
 ```
 
 Add or remove values one at a time:
@@ -54,11 +54,11 @@ cronExp.addValue('2', 'hour');
 cronExp.addValue('4', 'monthOfTheYear');
 cronExp.addValue('10', 'monthOfTheYear');
 cronExp.build();
-// '5,35 2 * 4,10 * *'
+// '5,35 2 * 4,10 *'
 
 cronExp.removeValue('5', 'minute');
 cronExp.build();
-// '35 2 * 4,10 * *'
+// '35 2 * 4,10 *'
 ```
 
 If you prefer to work with the expression object directly, use `getAll` and `setAll`:
@@ -68,7 +68,7 @@ var exp = cronExp.getAll();
 exp.dayOfTheMonth = ['7','14','21','28'];
 cronExp.setAll(exp);
 cronExp.build();
-// '35 2 7,14,21,28 4,10 * *'
+// '35 2 7,14,21,28 4,10 *'
 ```
 
 ##### Notes:

--- a/cron-builder.js
+++ b/cron-builder.js
@@ -5,7 +5,7 @@ var CronValidator = (function() {
     var validateExpression = function(expression) {
         // don't care if it's less than 6, we'll just set those to the default '*'
         if (Object.keys(expression).length > 6) {
-            throw new Error('Invalid cron expression; limited to 6 values.');
+            throw new Error('Invalid cron expression; limited to 5 values.');
         }
 
         for (var measureOfTime in expression) {
@@ -21,13 +21,12 @@ var CronValidator = (function() {
                 1: 'hour',
                 2: 'dayOfTheMonth',
                 3: 'monthOfTheYear',
-                4: 'dayOfTheWeek',
-                5: 'year'
+                4: 'dayOfTheWeek'
             },
             splitExpression = expression.split(' ');
 
         if (splitExpression.length > 6) {
-            throw new Error('Invalid cron expression; limited to 6 values.');
+            throw new Error('Invalid cron expression; limited to 5 values.');
         }
 
         for (var i = 0; i < splitExpression.length; i++) {
@@ -41,14 +40,13 @@ var CronValidator = (function() {
                 hour: {min: 0, max: 23},
                 dayOfTheMonth: {min: 1, max: 31},
                 monthOfTheYear: {min: 1, max: 12},
-                dayOfTheWeek: {min: 1, max: 7},
-                year: {min: 1900, max: 3000}
+                dayOfTheWeek: {min: 1, max: 7}
             },
             range,
             validChars = /^[0-9*-]/;
 
         if (!validatorObj[measureOfTime]) {
-            throw new Error('Invalid measureOfTime; Valid options are: "minute", "hour", "dayOfTheMonth", "monthOfTheYear", "dayOfTheWeek", & "year".');
+            throw new Error('Invalid measureOfTime; Valid options are: "minute", "hour", "dayOfTheMonth", "monthOfTheYear", & "dayOfTheWeek".');
         }
 
         if (!validChars.test(value)) {
@@ -101,7 +99,6 @@ var CronBuilder = function(initialExpression) {
             dayOfTheMonth: splitExpression[2] ? [splitExpression[2]] : DEFAULT_INTERVAL,
             monthOfTheYear: splitExpression[3] ? [splitExpression[3]] : DEFAULT_INTERVAL,
             dayOfTheWeek: splitExpression[4] ? [splitExpression[4]] : DEFAULT_INTERVAL,
-            year: splitExpression[5] ? [splitExpression[5]] : DEFAULT_INTERVAL
         };
     } else {
         this.expression = {
@@ -110,7 +107,6 @@ var CronBuilder = function(initialExpression) {
             dayOfTheMonth: DEFAULT_INTERVAL,
             monthOfTheYear: DEFAULT_INTERVAL,
             dayOfTheWeek: DEFAULT_INTERVAL,
-            year: DEFAULT_INTERVAL
         };
     }
 }
@@ -122,7 +118,6 @@ CronBuilder.prototype.build = function () {
         this.expression.dayOfTheMonth.join(','),
         this.expression.monthOfTheYear.join(','),
         this.expression.dayOfTheWeek.join(','),
-        this.expression.year.join(',')
     ].join(' ');
 };
 
@@ -140,7 +135,7 @@ CronBuilder.prototype.addValue = function (value, measureOfTime) {
 
 CronBuilder.prototype.removeValue = function (value, measureOfTime) {
     if (!this.expression[measureOfTime]) {
-        throw new Error('Invalid measureOfTime: Valid options are: "minute", "hour", "dayOfTheMonth", "monthOfTheYear", "dayOfTheWeek", & "year".');
+        throw new Error('Invalid measureOfTime: Valid options are: "minute", "hour", "dayOfTheMonth", "monthOfTheYear", & "dayOfTheWeek".');
     }
 
     if (this.expression[measureOfTime].length === 1 && this.expression[measureOfTime][0] === '*') {
@@ -158,7 +153,7 @@ CronBuilder.prototype.removeValue = function (value, measureOfTime) {
 
 CronBuilder.prototype.get = function (measureOfTime) {
     if (!this.expression[measureOfTime]) {
-        throw new Error('Invalid measureOfTime: Valid options are: "minute", "hour", "dayOfTheMonth", "monthOfTheYear", "dayOfTheWeek", & "year".');
+        throw new Error('Invalid measureOfTime: Valid options are: "minute", "hour", "dayOfTheMonth", "monthOfTheYear", & "dayOfTheWeek".');
     }
 
     return this.expression[measureOfTime].join(',');

--- a/test/test.js
+++ b/test/test.js
@@ -162,6 +162,7 @@ describe('cron-builder', function () {
     it('resets the value to the default "*" when removing the only value', function () {
         cron = new cb();
         cron.set(['7'], 'minute');
+        expect(cron.get('minute')).to.equal('7');
         cron.removeValue('7', 'minute');
         expect(cron.get('minute')).to.equal('*');
     });

--- a/test/test.js
+++ b/test/test.js
@@ -5,36 +5,35 @@ var chai = require('chai'),
 describe('cron-builder', function () {
     var cron;
 
-    it('defaults to "* * * * * *" when initialized without arguments', function () {
+    it('defaults to "* * * * *" when initialized without arguments', function () {
         cron = new cb();
         expect(cron.expression.minute).to.eql(['*']);
         expect(cron.expression.hour).to.eql(['*']);
         expect(cron.expression.dayOfTheMonth).to.eql(['*']);
         expect(cron.expression.monthOfTheYear).to.eql(['*']);
         expect(cron.expression.dayOfTheWeek).to.eql(['*']);
-        expect(cron.expression.year).to.eql(['*']);
     });
 
     it('returns a working cron expression when calling .build()', function () {
-        expect(cron.build()).to.equal('* * * * * *');
+        expect(cron.build()).to.equal('* * * * *');
     });
 
     it('sets a single value', function () {
         cron = new cb();
         expect(cron.set(['5'], 'hour')).to.equal('5');
-        expect(cron.build()).to.equal('* 5 * * * *');
+        expect(cron.build()).to.equal('* 5 * * *');
     });
 
     it('sets multiple values at once', function () {
         cron = new cb();
         expect(cron.set(['0', '10', '20', '30', '40', '50'], 'minute')).to.equal('0,10,20,30,40,50');
-        expect(cron.build()).to.equal('0,10,20,30,40,50 * * * * *');
+        expect(cron.build()).to.equal('0,10,20,30,40,50 * * * *');
     });
 
     it('sets a range', function () {
         cron = new cb();
         expect(cron.set(['5-7'], 'dayOfTheWeek')).to.equal('5-7');
-        expect(cron.build()).to.equal('* * * * 5-7 *');
+        expect(cron.build()).to.equal('* * * * 5-7');
     });
 
     it('multiple sets build the cron string accurately', function () {
@@ -43,8 +42,7 @@ describe('cron-builder', function () {
         cron.set(['6', '18'], 'hour');
         cron.set(['1', '15'], 'dayOfTheMonth');
         cron.set(['1-5'], 'dayOfTheWeek');
-        cron.set(['2015-2025'], 'year');
-        expect(cron.build()).to.equal('10,30,50 6,18 1,15 * 1-5 2015-2025');
+        expect(cron.build()).to.equal('10,30,50 6,18 1,15 * 1-5');
     });
 
     it('validates against setting an incorrect measureOfTime', function () {
@@ -59,7 +57,7 @@ describe('cron-builder', function () {
 
     it('validates against setting a value that is not a number or range of numbers', function () {
         cron = new cb();
-        expect(function () { cron.set(['!'], 'year') }).to.throw(Error);
+        expect(function () { cron.set(['!'], 'hour') }).to.throw(Error);
     });
 
     describe('validates against setting values outside the valid range', function () {
@@ -75,8 +73,6 @@ describe('cron-builder', function () {
 
         it('validates against setting a range that is out of bounds', function () {
             cron = new cb();
-            expect(function () { cron.set(['1834-2015'], 'year') }).to.throw(Error);
-
             expect(function () { cron.set(['20-60'], 'minute') }).to.throw(Error);
 
             expect(function () { cron.set(['12', '22-26', '15'], 'hour') }).to.throw(Error);
@@ -103,17 +99,16 @@ describe('cron-builder', function () {
         expect(getAllResponse).to.have.property('dayOfTheMonth').that.is.an('array').with.deep.property('[0]').that.deep.equals('*');
         expect(getAllResponse).to.have.property('monthOfTheYear').that.is.an('array').with.deep.property('[0]').that.deep.equals('*');
         expect(getAllResponse).to.have.property('dayOfTheWeek').that.is.an('array').with.deep.property('[0]').that.deep.equals('*');
-        expect(getAllResponse).to.have.property('year').that.is.an('array').with.deep.property('[0]').that.deep.equals('*');
     });
 
     it('sets the entire object when setAll is called', function () {
         cron = new cb();
         var getAllResponse = cron.getAll();
         getAllResponse.hour = ['13'];
-        getAllResponse.year = ['2015-2020'];
+        getAllResponse.monthOfTheYear = ['1-6'];
         getAllResponse.dayOfTheWeek = ['1,3,5,7'];
         cron.setAll(getAllResponse);
-        expect(cron.build()).to.equal('* 13 * * 1,3,5,7 2015-2020');
+        expect(cron.build()).to.equal('* 13 * 1-6 1,3,5,7');
     });
 
     it('validates setting all with too many keys in the expression object', function () {
@@ -134,7 +129,7 @@ describe('cron-builder', function () {
         cron = new cb();
         cron.addValue('5', 'minute');
         expect(cron.get('minute')).to.equal('5');
-        expect(cron.build()).to.equal('5 * * * * *');
+        expect(cron.build()).to.equal('5 * * * *');
     });
 
     it('adds a value to a measure of time that has been set to a number', function () {
@@ -166,87 +161,26 @@ describe('cron-builder', function () {
 
     it('resets the value to the default "*" when removing the only value', function () {
         cron = new cb();
-        cron.set(['2020'], 'year');
-        cron.removeValue('2020', 'year');
-        expect(cron.get('year')).to.equal('*');
+        cron.set(['7'], 'minute');
+        cron.removeValue('7', 'minute');
+        expect(cron.get('minute')).to.equal('*');
     });
 
     it('validates an invalid measure of time when removing a value', function () {
         cron = new cb();
-        expect(function () { cron.removeValue('ear') }).to.throw(Error);
+        expect(function () { cron.removeValue('ninute') }).to.throw(Error);
     });
 
     it('accepts a cron expression when instantiating', function () {
-        cron = new cb('30 0-6 * * 1-5 *');
-        expect(cron.build()).to.equal('30 0-6 * * 1-5 *');
+        cron = new cb('30 0-6 * * 1-5');
+        expect(cron.build()).to.equal('30 0-6 * * 1-5');
     });
 
     it('validates bad values when instantiating with an explicit expression', function () {
-        expect(function () { cron = new cb('30 0-6 * * 1-10 *') }).to.throw(Error);
+        expect(function () { cron = new cb('30 0-6 * * 1-10') }).to.throw(Error);
     });
 
     it('validates an expression that is too long when instantiating with an explicit expression', function () {
-        expect(function () { cron = new cb('30 0-6 * * 1-5 * * *') }).to.throw(Error);
+        expect(function () { cron = new cb('30 0-6 * * 1-5 * *') }).to.throw(Error);
     });
 });
-
-//var cb = require('./cron-builder.js'),
-//    test,
-//    test2,
-//    test2Exp;
-//
-//// init with default values ('* * * * * *')
-//test = new cb();
-//console.log('test init: ', test.build());
-//
-//test.addValue('3', 'minute');
-//test.addValue('56', 'minute'); // test multiple values
-//test.addValue('6', 'minutes'); // test spelling error
-//
-//test.addValue('1', 'hour');
-//test.addValue('5', 'hour'); // test multiple values
-//test.addValue('5', 'hour'); // test duplicates
-//test.addValue('6-24', 'hour');
-//
-//test.addValue('26', 'dayOfTheMonth');
-//
-//test.addValue('7', 'monthOfTheYear');
-//
-//test.addValue('5', 'dayOfTheWeek');
-//
-//test.addValue('2016', 'year');
-//
-//console.log('after adding values: ', test.build());
-//
-//test.removeValue('6-24', 'hour');
-//test.removeValue('6-24', 'hour');
-//
-//test.removeValue('2016', 'year');
-//console.log('after removing values: ', test.build());
-//
-//console.log('getting minutes values: ', test.get('minute'));
-//
-//console.log('setting new minutes', test.set(['13', '26', '54-57'], 'minute'));
-//test.set('5,6,7', 'dayOfTheMonth');
-//test.set(['1-6'], 'dayoftheweek');
-//
-//console.log('test final build', test.build());
-//
-//// test with explicit values
-//test2 = new cb('34 1 * *');
-//
-//console.log('test2 init', test2.build());
-//
-//test2Exp = test2.getAll();
-//console.log('test2Exp', test2Exp);
-//
-//// validation test for too many values
-//test2Exp.extraUnit = ['1'];
-//console.log('error, exp too long', test2.setAll(test2Exp))
-//
-//// validation test for bad values while using setAll
-//test2Exp = test2.getAll();
-//
-//
-//
-//console.log('test2 final build', test2.build());


### PR DESCRIPTION
this removes the 'year' field from the cron expression. now using https://en.wikipedia.org/wiki/Cron as the source of truth for proper cron syntax.
