### PR TITLE
Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![Build Status](https://travis-ci.org/srcclr/cron-builder.svg)](https://travis-ci.org/srcclr/cron-builder)
 # cron-builder
-cron-builder will manage the state of a cron expression allowing a user to manipulate it through a simple API. It is decoupled from the DOM and doesn't have an opinion about where it's being called from. cron-builder uses [this article](https://en.wikipedia.org/wiki/Cron) as a source of truth.
+The software utility *cron* is a time-based scheduler in Unix-like computer operating systems. A user may use cron to schedule jobs (commands or scripts) to run periodically at fixed times, dates, or intervals. A cron statement is composed of 5 fields separated by white space. The `*` character translates to "every", ie: "every minute" or "every day of the week". 
+
+cron-builder will manage the state of a cron expression allowing a user to manipulate it through a simple API. It is decoupled from the DOM and doesn't have an opinion about where it's being called from. cron-builder considers [this article](https://en.wikipedia.org/wiki/Cron) it's source of truth. 
 
 ### Install
 cron-builder is available on npm and bower:
@@ -48,7 +50,7 @@ cronExp.build();
 // '5,35 * * * *'
 ```
 
-Add or remove values one at a time:
+Or if you'd prefer to dd or remove values one at a time, use `addValue` and `removeValue`. These methods build or take away from what is currently set:
 ```JavaScript
 cronExp.addValue('2', 'hour');
 cronExp.addValue('4', 'monthOfTheYear');

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ API includes basic getters and setters:
 ```JavaScript
 cronExp.get('minute');
 // '*'
-cronExp.set('5,35', 'minute');
+cronExp.set('minute', '5,35');
 // '5,35'
 cronExp.get('minute');
 // '5,35'
@@ -52,13 +52,13 @@ cronExp.build();
 
 Or if you'd prefer to dd or remove values one at a time, use `addValue` and `removeValue`. These methods build or take away from what is currently set:
 ```JavaScript
-cronExp.addValue('2', 'hour');
-cronExp.addValue('4', 'monthOfTheYear');
-cronExp.addValue('10', 'monthOfTheYear');
+cronExp.addValue('hour', '2');
+cronExp.addValue('monthOfTheYear', '4');
+cronExp.addValue('monthOfTheYear', '10');
 cronExp.build();
 // '5,35 2 * 4,10 *'
 
-cronExp.removeValue('5', 'minute');
+cronExp.removeValue('minute', '5');
 cronExp.build();
 // '35 2 * 4,10 *'
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # cron-builder
 The software utility *cron* is a time-based scheduler in Unix-like computer operating systems. A user may use cron to schedule jobs (commands or scripts) to run periodically at fixed times, dates, or intervals. A cron statement is composed of 5 fields separated by white space. The `*` character translates to "every", ie: "every minute" or "every day of the week". 
 
-cron-builder will manage the state of a cron expression allowing a user to manipulate it through a simple API. It is decoupled from the DOM and doesn't have an opinion about where it's being called from. cron-builder considers [this article](https://en.wikipedia.org/wiki/Cron) it's source of truth. 
+cron-builder will manage the state of a cron expression, allowing a user to manipulate it through a simple API. It is decoupled from the DOM and doesn't have an opinion about where it's being called from. cron-builder considers [this article](https://en.wikipedia.org/wiki/Cron) its source of truth. 
 
 ### Install
 cron-builder is available on npm and bower:
@@ -50,7 +50,7 @@ cronExp.build();
 // '5,35 * * * *'
 ```
 
-Or if you'd prefer to dd or remove values one at a time, use `addValue` and `removeValue`. These methods build or take away from what is currently set:
+Or if you'd prefer to add or remove values one at a time, use `addValue` and `removeValue`. These methods build or take away from what is currently set:
 ```JavaScript
 cronExp.addValue('hour', '2');
 cronExp.addValue('monthOfTheYear', '4');

--- a/cron-builder.js
+++ b/cron-builder.js
@@ -10,7 +10,7 @@ var CronValidator = (function() {
 
         for (var measureOfTime in expression) {
             if (expression.hasOwnProperty(measureOfTime)) {
-                this.validateValue(expression[measureOfTime], measureOfTime);
+                this.validateValue(measureOfTime, expression[measureOfTime]);
             }
         }
     },
@@ -30,11 +30,11 @@ var CronValidator = (function() {
         }
 
         for (var i = 0; i < splitExpression.length; i++) {
-            this.validateValue(splitExpression[i], measureOfTimeMap[i]);
+            this.validateValue(measureOfTimeMap[i], splitExpression[i]);
         }
     },
 
-    validateValue = function(value, measureOfTime) {
+    validateValue = function(measureOfTime, value) {
         var validatorObj = {
                 minute: {min: 0, max: 59},
                 hour: {min: 0, max: 23},
@@ -121,8 +121,8 @@ CronBuilder.prototype.build = function () {
     ].join(' ');
 };
 
-CronBuilder.prototype.addValue = function (value, measureOfTime) {
-    CronValidator.validateValue(value, measureOfTime);
+CronBuilder.prototype.addValue = function (measureOfTime, value) {
+    CronValidator.validateValue(measureOfTime, value);
 
     if (this.expression[measureOfTime].length === 1 && this.expression[measureOfTime][0] === '*') {
         this.expression[measureOfTime] = [value];
@@ -133,7 +133,7 @@ CronBuilder.prototype.addValue = function (value, measureOfTime) {
     }
 };
 
-CronBuilder.prototype.removeValue = function (value, measureOfTime) {
+CronBuilder.prototype.removeValue = function (measureOfTime, value) {
     if (!this.expression[measureOfTime]) {
         throw new Error('Invalid measureOfTime: Valid options are: "minute", "hour", "dayOfTheMonth", "month", & "dayOfTheWeek".');
     }
@@ -159,13 +159,13 @@ CronBuilder.prototype.get = function (measureOfTime) {
     return this.expression[measureOfTime].join(',');
 };
 
-CronBuilder.prototype.set = function (value, measureOfTime) {
+CronBuilder.prototype.set = function (measureOfTime, value) {
     if (!Array.isArray(value)) {
         throw new Error('Invalid value; Value must be in the form of an Array.');
     }
 
     for(var i = 0; i < value.length; i++) {
-        CronValidator.validateValue(value[i], measureOfTime);
+        CronValidator.validateValue(measureOfTime, value[i]);
     }
 
     this.expression[measureOfTime] = value;

--- a/cron-builder.js
+++ b/cron-builder.js
@@ -20,7 +20,7 @@ var CronValidator = (function() {
                 0: 'minute',
                 1: 'hour',
                 2: 'dayOfTheMonth',
-                3: 'monthOfTheYear',
+                3: 'month',
                 4: 'dayOfTheWeek'
             },
             splitExpression = expression.split(' ');
@@ -39,14 +39,14 @@ var CronValidator = (function() {
                 minute: {min: 0, max: 59},
                 hour: {min: 0, max: 23},
                 dayOfTheMonth: {min: 1, max: 31},
-                monthOfTheYear: {min: 1, max: 12},
+                month: {min: 1, max: 12},
                 dayOfTheWeek: {min: 1, max: 7}
             },
             range,
             validChars = /^[0-9*-]/;
 
         if (!validatorObj[measureOfTime]) {
-            throw new Error('Invalid measureOfTime; Valid options are: "minute", "hour", "dayOfTheMonth", "monthOfTheYear", & "dayOfTheWeek".');
+            throw new Error('Invalid measureOfTime; Valid options are: "minute", "hour", "dayOfTheMonth", "month", & "dayOfTheWeek".');
         }
 
         if (!validChars.test(value)) {
@@ -97,7 +97,7 @@ var CronBuilder = function(initialExpression) {
             minute: splitExpression[0] ? [splitExpression[0]] : DEFAULT_INTERVAL,
             hour: splitExpression[1] ? [splitExpression[1]] : DEFAULT_INTERVAL,
             dayOfTheMonth: splitExpression[2] ? [splitExpression[2]] : DEFAULT_INTERVAL,
-            monthOfTheYear: splitExpression[3] ? [splitExpression[3]] : DEFAULT_INTERVAL,
+            month: splitExpression[3] ? [splitExpression[3]] : DEFAULT_INTERVAL,
             dayOfTheWeek: splitExpression[4] ? [splitExpression[4]] : DEFAULT_INTERVAL,
         };
     } else {
@@ -105,7 +105,7 @@ var CronBuilder = function(initialExpression) {
             minute: DEFAULT_INTERVAL,
             hour: DEFAULT_INTERVAL,
             dayOfTheMonth: DEFAULT_INTERVAL,
-            monthOfTheYear: DEFAULT_INTERVAL,
+            month: DEFAULT_INTERVAL,
             dayOfTheWeek: DEFAULT_INTERVAL,
         };
     }
@@ -116,7 +116,7 @@ CronBuilder.prototype.build = function () {
         this.expression.minute.join(','),
         this.expression.hour.join(','),
         this.expression.dayOfTheMonth.join(','),
-        this.expression.monthOfTheYear.join(','),
+        this.expression.month.join(','),
         this.expression.dayOfTheWeek.join(','),
     ].join(' ');
 };
@@ -135,7 +135,7 @@ CronBuilder.prototype.addValue = function (value, measureOfTime) {
 
 CronBuilder.prototype.removeValue = function (value, measureOfTime) {
     if (!this.expression[measureOfTime]) {
-        throw new Error('Invalid measureOfTime: Valid options are: "minute", "hour", "dayOfTheMonth", "monthOfTheYear", & "dayOfTheWeek".');
+        throw new Error('Invalid measureOfTime: Valid options are: "minute", "hour", "dayOfTheMonth", "month", & "dayOfTheWeek".');
     }
 
     if (this.expression[measureOfTime].length === 1 && this.expression[measureOfTime][0] === '*') {
@@ -153,7 +153,7 @@ CronBuilder.prototype.removeValue = function (value, measureOfTime) {
 
 CronBuilder.prototype.get = function (measureOfTime) {
     if (!this.expression[measureOfTime]) {
-        throw new Error('Invalid measureOfTime: Valid options are: "minute", "hour", "dayOfTheMonth", "monthOfTheYear", & "dayOfTheWeek".');
+        throw new Error('Invalid measureOfTime: Valid options are: "minute", "hour", "dayOfTheMonth", "month", & "dayOfTheWeek".');
     }
 
     return this.expression[measureOfTime].join(',');

--- a/test/test.js
+++ b/test/test.js
@@ -20,28 +20,28 @@ describe('cron-builder', function () {
 
     it('sets a single value', function () {
         cron = new cb();
-        expect(cron.set(['5'], 'hour')).to.equal('5');
+        expect(cron.set('hour', ['5'])).to.equal('5');
         expect(cron.build()).to.equal('* 5 * * *');
     });
 
     it('sets multiple values at once', function () {
         cron = new cb();
-        expect(cron.set(['0', '10', '20', '30', '40', '50'], 'minute')).to.equal('0,10,20,30,40,50');
+        expect(cron.set('minute', ['0', '10', '20', '30', '40', '50'])).to.equal('0,10,20,30,40,50');
         expect(cron.build()).to.equal('0,10,20,30,40,50 * * * *');
     });
 
     it('sets a range', function () {
         cron = new cb();
-        expect(cron.set(['5-7'], 'dayOfTheWeek')).to.equal('5-7');
+        expect(cron.set('dayOfTheWeek', ['5-7'])).to.equal('5-7');
         expect(cron.build()).to.equal('* * * * 5-7');
     });
 
     it('multiple sets build the cron string accurately', function () {
         cron = new cb();
-        cron.set(['10', '30', '50'], 'minute');
-        cron.set(['6', '18'], 'hour');
-        cron.set(['1', '15'], 'dayOfTheMonth');
-        cron.set(['1-5'], 'dayOfTheWeek');
+        cron.set('minute', ['10', '30', '50']);
+        cron.set('hour', ['6', '18']);
+        cron.set('dayOfTheMonth', ['1', '15']);
+        cron.set('dayOfTheWeek', ['1-5']);
         expect(cron.build()).to.equal('10,30,50 6,18 1,15 * 1-5');
     });
 
@@ -81,7 +81,7 @@ describe('cron-builder', function () {
 
     it('gets a single value', function () {
         cron = new cb();
-        cron.set(['30'], 'minute');
+        cron.set('minute', ['30']);
         expect(cron.get('minute')).to.equal('30');
     });
 
@@ -127,23 +127,23 @@ describe('cron-builder', function () {
 
     it('adds a value to a measureOfTime that is set to "*"', function () {
         cron = new cb();
-        cron.addValue('5', 'minute');
+        cron.addValue('minute', '5');
         expect(cron.get('minute')).to.equal('5');
         expect(cron.build()).to.equal('5 * * * *');
     });
 
     it('adds a value to a measure of time that has been set to a number', function () {
         cron = new cb();
-        cron.addValue('5', 'hour');
-        cron.addValue('10', 'hour');
+        cron.addValue('hour', '5');
+        cron.addValue('hour', '10');
         expect(cron.get('hour')).to.equal('5,10');
     });
 
     it('validates duplicate values', function () {
         cron = new cb();
-        cron.addValue('5', 'dayOfTheMonth');
-        cron.addValue('15', 'dayOfTheMonth');
-        cron.addValue('5', 'dayOfTheMonth');
+        cron.addValue('dayOfTheMonth', '5');
+        cron.addValue('dayOfTheMonth', '15');
+        cron.addValue('dayOfTheMonth', '5');
         expect(cron.get('dayOfTheMonth')).to.equal('5,15');
     });
 
@@ -154,16 +154,16 @@ describe('cron-builder', function () {
 
     it('removes a value that exists with other values', function () {
         cron = new cb();
-        cron.set(['2', '4'], 'dayOfTheWeek');
-        cron.removeValue('4', 'dayOfTheWeek');
+        cron.set('dayOfTheWeek', ['2', '4']);
+        cron.removeValue('dayOfTheWeek', '4');
         expect(cron.get('dayOfTheWeek')).to.equal('2');
     });
 
     it('resets the value to the default "*" when removing the only value', function () {
         cron = new cb();
-        cron.set(['7'], 'minute');
+        cron.set('minute', ['7']);
         expect(cron.get('minute')).to.equal('7');
-        cron.removeValue('7', 'minute');
+        cron.removeValue('minute', '7');
         expect(cron.get('minute')).to.equal('*');
     });
 

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ describe('cron-builder', function () {
         expect(cron.expression.minute).to.eql(['*']);
         expect(cron.expression.hour).to.eql(['*']);
         expect(cron.expression.dayOfTheMonth).to.eql(['*']);
-        expect(cron.expression.monthOfTheYear).to.eql(['*']);
+        expect(cron.expression.month).to.eql(['*']);
         expect(cron.expression.dayOfTheWeek).to.eql(['*']);
     });
 
@@ -97,7 +97,7 @@ describe('cron-builder', function () {
         expect(getAllResponse).to.have.property('minute').that.is.an('array').with.deep.property('[0]').that.deep.equals('*');
         expect(getAllResponse).to.have.property('hour').that.is.an('array').with.deep.property('[0]').that.deep.equals('*');
         expect(getAllResponse).to.have.property('dayOfTheMonth').that.is.an('array').with.deep.property('[0]').that.deep.equals('*');
-        expect(getAllResponse).to.have.property('monthOfTheYear').that.is.an('array').with.deep.property('[0]').that.deep.equals('*');
+        expect(getAllResponse).to.have.property('month').that.is.an('array').with.deep.property('[0]').that.deep.equals('*');
         expect(getAllResponse).to.have.property('dayOfTheWeek').that.is.an('array').with.deep.property('[0]').that.deep.equals('*');
     });
 
@@ -105,7 +105,7 @@ describe('cron-builder', function () {
         cron = new cb();
         var getAllResponse = cron.getAll();
         getAllResponse.hour = ['13'];
-        getAllResponse.monthOfTheYear = ['1-6'];
+        getAllResponse.month = ['1-6'];
         getAllResponse.dayOfTheWeek = ['1,3,5,7'];
         cron.setAll(getAllResponse);
         expect(cron.build()).to.equal('* 13 * 1-6 1,3,5,7');


### PR DESCRIPTION
refactor based on feedback. accomplishes the following:
- `measureOfTime` is always the first argument passed to the method, so as to be consistent with methods that don't have a `value` argument
- improved clarity in the readme for what a cron is and why a user would need one
- improved clarity in the readme for the `addValue` and `removeValue` methods
- `monthOfTheYear` is now just `month`
