### PR TITLE
Builder closure

### DIFF
--- a/cron-builder.js
+++ b/cron-builder.js
@@ -157,17 +157,21 @@ var CronBuilder = function(initialExpression) {
         };
     }
 
+    var _getExpression = function() {
+        return _expression;
+    }
+
     /**
      * builds a working cron expression based on the state of the cron object
      * @returns {string} - working cron expression
      */
     var build = function() {
         return [
-            _expression.minute.join(','),
-            _expression.hour.join(','),
-            _expression.dayOfTheMonth.join(','),
-            _expression.month.join(','),
-            _expression.dayOfTheWeek.join(','),
+            _getExpression().minute.join(','),
+            _getExpression().hour.join(','),
+            _getExpression().dayOfTheMonth.join(','),
+            _getExpression().month.join(','),
+            _getExpression().dayOfTheWeek.join(','),
         ].join(' ');
     };
 
@@ -180,11 +184,11 @@ var CronBuilder = function(initialExpression) {
     var addValue = function(measureOfTime, value) {
         CronValidator.validateValue(measureOfTime, value);
 
-        if (_expression[measureOfTime].length === 1 && _expression[measureOfTime][0] === '*') {
-            _expression[measureOfTime] = [value];
+        if (_getExpression()[measureOfTime].length === 1 && _getExpression()[measureOfTime][0] === '*') {
+            _getExpression()[measureOfTime] = [value];
         } else {
-            if (_expression[measureOfTime].indexOf(value) < 0) {
-                _expression[measureOfTime].push(value);
+            if (_getExpression()[measureOfTime].indexOf(value) < 0) {
+                _getExpression()[measureOfTime].push(value);
             }
         }
     };
@@ -196,19 +200,19 @@ var CronBuilder = function(initialExpression) {
      * @throws {Error} if measureOfTime is bogus.
      */
     var removeValue = function (measureOfTime, value) {
-        if (!_expression[measureOfTime]) {
+        if (!_getExpression()[measureOfTime]) {
             throw new Error('Invalid measureOfTime: Valid options are: ' + CronValidator.measureOfTimeValues.join(', '));
         }
 
-        if (_expression[measureOfTime].length === 1 && _expression[measureOfTime][0] === '*') {
+        if (_getExpression()[measureOfTime].length === 1 && _getExpression()[measureOfTime][0] === '*') {
             return 'The value for "' + measureOfTime + '" is already at the default value of "*" - this is a no-op.';
         }
 
-        _expression[measureOfTime] = _expression[measureOfTime].filter(function (timeValue) {
+        _getExpression()[measureOfTime] = _getExpression()[measureOfTime].filter(function (timeValue) {
            return value !== timeValue;
         });
 
-        if (!_expression[measureOfTime].length) {
+        if (!_getExpression()[measureOfTime].length) {
             _expression[measureOfTime] = DEFAULT_INTERVAL;
         }
     };
@@ -220,11 +224,11 @@ var CronBuilder = function(initialExpression) {
      * @throws {Error} if the measureOfTime is not one of the permitted values.
      */
     var get = function (measureOfTime) {
-        if (!_expression[measureOfTime]) {
+        if (!_getExpression()[measureOfTime]) {
             throw new Error('Invalid measureOfTime: Valid options are: ' + CronValidator.measureOfTimeValues.join(', '));
         }
 
-        return _expression[measureOfTime].join(',');
+        return _getExpression()[measureOfTime].join(',');
     };
 
     /**
@@ -260,7 +264,7 @@ var CronBuilder = function(initialExpression) {
      * }}
      */
     var getAll = function () {
-        return _expression;
+        return _getExpression();
     };
 
     /**

--- a/cron-builder.js
+++ b/cron-builder.js
@@ -166,12 +166,13 @@ var CronBuilder = function(initialExpression) {
      * @returns {string} - working cron expression
      */
     var build = function() {
+        var expression = _getExpression();
         return [
-            _getExpression().minute.join(','),
-            _getExpression().hour.join(','),
-            _getExpression().dayOfTheMonth.join(','),
-            _getExpression().month.join(','),
-            _getExpression().dayOfTheWeek.join(','),
+            expression.minute.join(','),
+            expression.hour.join(','),
+            expression.dayOfTheMonth.join(','),
+            expression.month.join(','),
+            expression.dayOfTheWeek.join(','),
         ].join(' ');
     };
 
@@ -183,12 +184,12 @@ var CronBuilder = function(initialExpression) {
      */
     var addValue = function(measureOfTime, value) {
         CronValidator.validateValue(measureOfTime, value);
-
-        if (_getExpression()[measureOfTime].length === 1 && _getExpression()[measureOfTime][0] === '*') {
-            _getExpression()[measureOfTime] = [value];
+        var expression = _getExpression();
+        if (expression[measureOfTime].length === 1 && expression[measureOfTime][0] === '*') {
+            expression[measureOfTime] = [value];
         } else {
-            if (_getExpression()[measureOfTime].indexOf(value) < 0) {
-                _getExpression()[measureOfTime].push(value);
+            if (expression[measureOfTime].indexOf(value) < 0) {
+                expression[measureOfTime].push(value);
             }
         }
     };
@@ -200,20 +201,21 @@ var CronBuilder = function(initialExpression) {
      * @throws {Error} if measureOfTime is bogus.
      */
     var removeValue = function (measureOfTime, value) {
-        if (!_getExpression()[measureOfTime]) {
+        var expression = _getExpression();
+        if (!expression[measureOfTime]) {
             throw new Error('Invalid measureOfTime: Valid options are: ' + CronValidator.measureOfTimeValues.join(', '));
         }
 
-        if (_getExpression()[measureOfTime].length === 1 && _getExpression()[measureOfTime][0] === '*') {
+        if (expression[measureOfTime].length === 1 && expression[measureOfTime][0] === '*') {
             return 'The value for "' + measureOfTime + '" is already at the default value of "*" - this is a no-op.';
         }
 
-        _getExpression()[measureOfTime] = _getExpression()[measureOfTime].filter(function (timeValue) {
+        expression[measureOfTime] = expression[measureOfTime].filter(function (timeValue) {
            return value !== timeValue;
         });
 
-        if (!_getExpression()[measureOfTime].length) {
-            _expression[measureOfTime] = DEFAULT_INTERVAL;
+        if (!expression[measureOfTime].length) {
+            expression[measureOfTime] = DEFAULT_INTERVAL;
         }
     };
 
@@ -224,11 +226,12 @@ var CronBuilder = function(initialExpression) {
      * @throws {Error} if the measureOfTime is not one of the permitted values.
      */
     var get = function (measureOfTime) {
-        if (!_getExpression()[measureOfTime]) {
+        var expression = _getExpression();
+        if (!expression[measureOfTime]) {
             throw new Error('Invalid measureOfTime: Valid options are: ' + CronValidator.measureOfTimeValues.join(', '));
         }
 
-        return _getExpression()[measureOfTime].join(',');
+        return expression[measureOfTime].join(',');
     };
 
     /**

--- a/test/test.js
+++ b/test/test.js
@@ -7,11 +7,11 @@ describe('cron-builder', function () {
 
     it('defaults to "* * * * *" when initialized without arguments', function () {
         cron = new cb();
-        expect(cron.expression.minute).to.eql(['*']);
-        expect(cron.expression.hour).to.eql(['*']);
-        expect(cron.expression.dayOfTheMonth).to.eql(['*']);
-        expect(cron.expression.month).to.eql(['*']);
-        expect(cron.expression.dayOfTheWeek).to.eql(['*']);
+        expect(cron.get('minute')).to.eql('*');
+        expect(cron.get('hour')).to.eql('*');
+        expect(cron.get('dayOfTheMonth')).to.eql('*');
+        expect(cron.get('month')).to.eql('*');
+        expect(cron.get('dayOfTheWeek')).to.eql('*');
     });
 
     it('returns a working cron expression when calling .build()', function () {


### PR DESCRIPTION
- Switch from `.prototype` structure to module pattern structure in 1afa8d7 (see https://toddmotto.com/mastering-the-module-pattern/ for more info)
- Creates a private getter to access the expression, instead of accessing it directly with `this.expression`
- Fixes test that was accessing the `expression` directly to use `get` method instead
